### PR TITLE
Concurrent instances for mapnik

### DIFF
--- a/mapproxy/config/loader.py
+++ b/mapproxy/config/loader.py
@@ -918,9 +918,13 @@ class MapnikSourceConfiguration(SourceConfiguration):
         else:
             reuse_map_objects = False
 
+        concurrent_tile_creators = self.context.globals.get_value('concurrent_tile_creators', self.conf,
+            global_key='cache.concurrent_tile_creators')
+
         return MapnikSource(mapfile, layers=layers, image_opts=image_opts,
-            coverage=coverage, res_range=res_range, lock=lock,
-            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor)
+                            coverage=coverage, res_range=res_range, lock=lock,
+                            reuse_map_objects=reuse_map_objects, scale_factor=scale_factor,
+                            concurrent_tile_creators=concurrent_tile_creators)
 
 class TileSourceConfiguration(SourceConfiguration):
     supports_meta_tiles = False

--- a/mapproxy/source/mapnik.py
+++ b/mapproxy/source/mapnik.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import sys
 import time
 import threading
+import multiprocessing
 
 from mapproxy.grid import tile_grid
 from mapproxy.image import ImageSource
@@ -49,7 +50,8 @@ log = logging.getLogger(__name__)
 class MapnikSource(MapLayer):
     supports_meta_tiles = True
     def __init__(self, mapfile, layers=None, image_opts=None, coverage=None,
-        res_range=None, lock=None, reuse_map_objects=False, scale_factor=None):
+                 res_range=None, lock=None, reuse_map_objects=False, scale_factor=None,
+                 concurrent_tile_creators=None):
         MapLayer.__init__(self, image_opts=image_opts)
         self.mapfile = mapfile
         self.coverage = coverage
@@ -57,8 +59,9 @@ class MapnikSource(MapLayer):
         self.layers = set(layers) if layers else None
         self.scale_factor = scale_factor
         self.lock = lock
-        self._map_objs = {}
-        self._map_objs_lock = threading.Lock()
+        # global objects to support multiprocessing
+        global _map_objs
+        _map_objs = {}
         self._cache_map_obj = reuse_map_objects
         if self.coverage:
             self.extent = MapExtent(self.coverage.bbox, self.coverage.srs)
@@ -93,24 +96,42 @@ class MapnikSource(MapLayer):
         else:
             return self.render_mapfile(mapfile, query)
 
-    def map_obj(self, mapfile):
-        if not self._cache_map_obj:
-            m = mapnik.Map(0, 0)
-            mapnik.load_map(m, str(mapfile))
-            return m
+    def _create_map_obj(self, mapfile):
+        m = mapnik.Map(0, 0)
+        mapnik.load_map(m, str(mapfile))
+        return m
 
+    def map_obj(self, mapfile):
         # cache loaded map objects
-        # only works when a single proc/thread accesses this object
+        # only works when a single proc/thread accesses the map
         # (forking the render process doesn't work because of open database
         #  file handles that gets passed to the child)
-        if mapfile not in self._map_objs:
-            with self._map_objs_lock:
-                if mapfile not in self._map_objs:
-                    m = mapnik.Map(0, 0)
-                    mapnik.load_map(m, str(mapfile))
-                    self._map_objs[mapfile] = m
+        # segment the cache by process and thread to avoid interference
+        if self._cache_map_obj:
+            cachekey = None # renderd guarantees that there are no concurrency issues
+        else:
+            thread_id = threading.current_thread().ident
+            process_id = multiprocessing.current_process()._identity
+            cachekey = (process_id, thread_id, mapfile)
+        if cachekey not in _map_objs:
+            _map_objs[cachekey] = self._create_map_obj(mapfile)
 
-        return self._map_objs[mapfile]
+        # clean up no longer used cached maps
+        process_cache_keys = [k for k in _map_objs.keys()
+                              if k[0] == process_id]
+        if len(process_cache_keys) > (5 + threading.active_count()):
+            active_thread_ids = set(i.ident for i in threading.enumerate())
+            for k in process_cache_keys:
+                if not k[1] in active_thread_ids and k in _map_objs:
+                    try:
+                        m = _map_objs[k]
+                        del _map_objs[k]
+                    except KeyError:
+                        continue
+                    m.remove_all() # cleanup
+                    mapnik.clear_cache()
+
+        return _map_objs[cachekey]
 
     def render_mapfile(self, mapfile, query):
         return run_non_blocking(self._render_mapfile, (mapfile, query))


### PR DESCRIPTION
This pull-request recovers caching of the mapnik object by segmenting the cache by process_id and thread_id, both for seeding and for serving. To avoid delays in serving after threads are reaped, mapnik.Map(…) objects are pregenerated for the least recently used mapfile.

The segmented cache speeds up the seeding process in our setup by at least factor 4 and pregeneration of the maps reduces the delay for serving not-yet-cached map tiles is reduced from ~5 seconds to ~1 second.

Internal version within the Disy reporsitory until the legal side is cleared up.